### PR TITLE
chore: add the ability to prerelease in other dist tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,14 @@ aliases:
   - &execute_on_release
     filters:
       tags:
-        only: /v?[0-9]+(\.[0-9]+)+([-+\.][0-9a-zA-Z]+)*/
+        only: /v?[0-9]+(\.[0-9]+)+/
+      branches:
+        ignore:
+          - /.*/
+  - &execute_on_release_prerelease
+    filters:
+      tags:
+        only: /v?[0-9]+(\.[0-9]+)+([-+\.][0-9a-zA-Z]+)+/
       branches:
         ignore:
           - /.*/
@@ -100,6 +107,18 @@ jobs:
           name: Publish
           command: yarn release:publish --yes
 
+  publish_prerelease:
+    <<: *defaults
+    <<: *default_executor
+    steps:
+      - *restore_repo
+      - run:
+          name: 'Setup publish credentials'
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+      - run:
+          name: Publish prerelease
+          command: yarn release:publish-prerelease --yes
+
 workflows:
   version: 2
   workflow:
@@ -124,3 +143,9 @@ workflows:
             - test_node10
             - test_node8
           <<: *execute_on_release
+      - publish_prerelease:
+          requires:
+            - test_node12
+            - test_node10
+            - test_node8
+          <<: *execute_on_release_prerelease

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,14 +31,14 @@ aliases:
   - &execute_on_release
     filters:
       tags:
-        only: /v?[0-9]+(\.[0-9]+)+/
+        only: /v?[0-9]+(\.[0-9]+)*/
       branches:
         ignore:
           - /.*/
   - &execute_on_release_prerelease
     filters:
       tags:
-        only: /v?[0-9]+(\.[0-9]+)+([-+\.][0-9a-zA-Z]+)+/
+        only: /v?[0-9]+(\.[0-9]+)*([-+][a-zA-Z0-9]+)+([-+\.][a-zA-Z0-9-]+)*/
       branches:
         ignore:
           - /.*/

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     "build": "lerna run build",
     "lint": "lerna run lint",
     "release": "lerna version --conventional-commits",
+    "release:prerelease": "lerna version --conventional-commits --conventional-prerelease --preid next",
+    "release:from-prerelease": "lerna version --conventional-commits --conventional-graduate",
     "release:publish": "lerna publish from-git",
+    "release:publish-prerelease": "lerna publish from-git --pre-dist-tag next",
     "test": "lerna run test"
   },
   "husky": {


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

Also, we need the scopes involved (aka package folder names):

eg:

-->
**Type:** chore
**Scope:** ci

The following has been addressed in the PR:

*  There is a related issue? No
*  Unit or Functional tests are included in the PR No

**Description:**
We want to make easier the release process, and delegate all the work in commons scripts and in a CI remove a lot of headaches and problems.

The new scripts layout are:
- Versioning:
    - release - a simple release following Conventional Commits (`vX.Y.Z`)
    - release:prerelease - with Conventional Commits it will determine next latest version and with Conventional Prerelease and preid it will create the prerelease (`vX.Y.Z-next.N`)
    - release:from-prerelease - with Conventional Commits it will determine next latest version and with Conventional Graduate it will exit from prerelease cycle (`vX.Y.Z-next.N` -> `vX.Y.Z`)
- Publishing:
    - release:publish - publish packages (`package@latest`)
    - release:publish-prerelease - publish using 'next' dist tag in registry (`package@next`)

Now, CircleCI config knows how to recognize if we are publishing a normal version or a prerelease, so it will send the specific tag to the registry

<!-- Resolves #??? -->
