### PR TITLE
refactor(eslint-config): refactor project structure to separate rules in categories

### DIFF
--- a/tools/eslint-config/.editorconfig
+++ b/tools/eslint-config/.editorconfig
@@ -1,0 +1,12 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# 2 space indentation
+[{.,}*.js]
+indent_style = space
+indent_size = 2

--- a/tools/eslint-config/index.js
+++ b/tools/eslint-config/index.js
@@ -1,81 +1,24 @@
 module.exports = {
-  plugins: ['verdaccio', '@typescript-eslint', 'jest'],
-
   extends: [
-    'eslint:recommended',
-    'google',
-    'plugin:jest/recommended',
-    'plugin:prettier/recommended',
-    'plugin:verdaccio/recommended',
-    'plugin:@typescript-eslint/recommended'
-  ],
-
-  parser: '@typescript-eslint/parser',
+    './rules/base',
+    './rules/typescript',
+    './rules/import',
+    './rules/prettier'
+  ].map(require.resolve),
+  env: {
+    es6: true,
+    node: true,
+    jest: true
+  },
+  globals: {
+    __APP_VERSION__: true
+  },
   parserOptions: {
     sourceType: 'module',
-    ecmaVersion: 7,
+    ecmaVersion: 2019,
     ecmaFeatures: {
       impliedStrict: true,
       jsx: true
     }
-  },
-
-  env: {
-    node: true,
-    es6: true,
-    jest: true
-  },
-
-  globals: {
-    __APP_VERSION__: true
-  },
-
-  rules: {
-    'prettier/prettier': ['error', { singleQuote: true }],
-    '@typescript-eslint/camelcase': 'off',
-    '@typescript-eslint/indent': ['error', 2],
-    '@typescript-eslint/explicit-member-accessibility': ['warn'],
-    'no-tabs': 'off',
-    'keyword-spacing': 'off',
-    'padded-blocks': 'off',
-    'no-useless-escape': 'off',
-    'handle-callback-err': 'error',
-    'no-debugger': 'error',
-    'no-fallthrough': 'error',
-    curly: 'error',
-    'eol-last': 'warn',
-    'no-irregular-whitespace': 'warn',
-    'no-mixed-spaces-and-tabs': ['warn', 'smart-tabs'],
-    'no-trailing-spaces': 'warn',
-    'no-new-require': 'error',
-    'no-undef': 'error',
-    'no-unreachable': 'error',
-    'no-unused-vars': [
-      'error',
-      {
-        vars: 'all',
-        args: 'none'
-      }
-    ],
-    'max-len': ['warn', 160],
-    semi: ['error', 'always'],
-    camelcase: 'off',
-    'require-jsdoc': 'off',
-    'valid-jsdoc': 'off',
-    'prefer-spread': 'warn',
-    'prefer-rest-params': 'warn',
-    'no-var': 'error',
-    'no-constant-condition': 'error',
-    'no-empty': 'error',
-    'guard-for-in': 'error',
-    'no-invalid-this': 'error',
-    'new-cap': 'error',
-    'one-var': 'error',
-    'no-console': [
-      'error',
-      {
-        allow: ['warn']
-      }
-    ]
   }
 };

--- a/tools/eslint-config/package.json
+++ b/tools/eslint-config/package.json
@@ -13,6 +13,9 @@
     "access": "public"
   },
   "main": "index.js",
+  "files": [
+    "rules/"
+  ],
   "engines": {
     "node": ">= 8"
   },
@@ -35,7 +38,8 @@
   },
   "scripts": {
     "lint": "eslint \"**/*.js\"",
-    "lint:stage": "lint-staged"
+    "lint:stage": "lint-staged",
+    "test-prettier-rules": "eslint --print-config index.js | eslint-config-prettier-check"
   },
   "lint-staged": {
     "**/*.js": [

--- a/tools/eslint-config/rules/base.js
+++ b/tools/eslint-config/rules/base.js
@@ -1,0 +1,38 @@
+module.exports = {
+  extends: ['eslint:recommended', 'google'],
+  rules: {
+    'keyword-spacing': 'off',
+    'no-tabs': 'off',
+    'no-useless-escape': 'off',
+    'padded-blocks': 'off',
+    'require-jsdoc': 'off',
+    'valid-jsdoc': 'off',
+
+    'eol-last': 'warn',
+    'no-irregular-whitespace': 'warn',
+    'no-mixed-spaces-and-tabs': ['warn', 'smart-tabs'],
+    'no-trailing-spaces': 'warn',
+
+    camelcase: 'off',
+    curly: 'error',
+    'guard-for-in': 'error',
+    'handle-callback-err': 'error',
+    'new-cap': 'error',
+    'max-len': ['warn', 160],
+    'no-console': ['error', { allow: ['warn'] }],
+    'no-constant-condition': 'error',
+    'no-debugger': 'error',
+    'no-empty': 'error',
+    'no-fallthrough': 'error',
+    'no-invalid-this': 'error',
+    'no-new-require': 'error',
+    'no-undef': 'error',
+    'no-unreachable': 'error',
+    'no-unused-vars': ['error', { vars: 'all', args: 'none' }],
+    'no-var': 'error',
+    'one-var': 'error',
+    'prefer-rest-params': 'warn',
+    'prefer-spread': 'warn',
+    semi: ['error', 'always']
+  }
+};

--- a/tools/eslint-config/rules/import.js
+++ b/tools/eslint-config/rules/import.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['plugin:import/typescript']
+};

--- a/tools/eslint-config/rules/jest.js
+++ b/tools/eslint-config/rules/jest.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['plugin:jest/recommended']
+};

--- a/tools/eslint-config/rules/prettier.js
+++ b/tools/eslint-config/rules/prettier.js
@@ -1,0 +1,12 @@
+module.exports = {
+  extends: ['plugin:prettier/recommended', 'prettier/@typescript-eslint'],
+  rules: {
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+        singleQuote: true
+      }
+    ]
+  }
+};

--- a/tools/eslint-config/rules/typescript.js
+++ b/tools/eslint-config/rules/typescript.js
@@ -1,0 +1,11 @@
+module.exports = {
+  extends: [
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended'
+  ],
+  rules: {
+    '@typescript-eslint/camelcase': 'off',
+    '@typescript-eslint/indent': ['error', 2],
+    '@typescript-eslint/explicit-member-accessibility': ['warn']
+  }
+};


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

Also, we need the scopes involved (aka package folder names):

eg:

-->
**Type:** refactor
**Scope:** eslint-config

The following has been addressed in the PR:

*  There is a related issue? **No*
*  Unit or Functional tests are included in the PR **No**

**Description:** separate in different files the rules with their own scope, so in a future we can maintain rules better. An example is if we need to improve Prettier settings, we can go to _rules/prettier.js_ instead of searching in a whole world of mixed rules

<!-- Resolves #??? -->
