### PR TITLE
ci: publish pacakges to an in-memory registry to ensure publish works well

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,44 @@ jobs:
           name: Test with Node 8
           command: yarn test
 
+  test_publish:
+    <<: *defaults
+    <<: *default_executor
+    steps:
+      - *restore_repo
+      - run:
+          name: 'Install tools to run a Verdaccio in memory'
+          command: |
+            yarn global add verdaccio verdaccio-auth-memory verdaccio-memory nohup npm-auth-to-token
+            tmp_registry_log=`mktemp`
+            nohup verdaccio -c verdaccio.yml 2>&1 &>$tmp_registry_log &
+            grep -q 'http address' <(tail -f $tmp_registry_log)
+      - run:
+          name: 'Setup local registry credentials'
+          command: npm-auth-to-token -u user -p test -e test@test.com -r http://localhost:4873
+      - run:
+          name: 'Try to publish release to local registry'
+          command: yarn release:publish --yes --registry=http://localhost:4873
+
+  test_publish_prerelease:
+    <<: *defaults
+    <<: *default_executor
+    steps:
+      - *restore_repo
+      - run:
+          name: 'Install tools to run a Verdaccio in memory'
+          command: |
+            yarn global add verdaccio verdaccio-auth-memory verdaccio-memory nohup npm-auth-to-token
+            tmp_registry_log=`mktemp`
+            nohup verdaccio -c verdaccio.yml 2>&1 &>$tmp_registry_log &
+            grep -q 'http address' <(tail -f $tmp_registry_log)
+      - run:
+          name: 'Setup local registry credentials'
+          command: npm-auth-to-token -u user -p test -e test@test.com -r http://localhost:4873
+      - run:
+          name: 'Try to publish release to local registry'
+          command: yarn release:publish-prerelease --yes --registry=http://localhost:4873
+
   publish:
     <<: *defaults
     <<: *default_executor
@@ -152,17 +190,25 @@ workflows:
           requires:
             - prepare
           <<: *ignore_non_dev_branches
-      - publish:
+      - test_publish:
           requires:
             - lint
             - test_node12
             - test_node10
             - test_node8
           <<: *execute_on_release
-      - publish_prerelease:
+      - test_publish_prerelease:
           requires:
             - lint
             - test_node12
             - test_node10
             - test_node8
+          <<: *execute_on_release_prerelease
+      - publish:
+          requires:
+            - test_publish
+          <<: *execute_on_release
+      - publish_prerelease:
+          requires:
+            - test_publish_prerelease
           <<: *execute_on_release_prerelease

--- a/verdaccio.yml
+++ b/verdaccio.yml
@@ -1,0 +1,28 @@
+# Verdaccio in-memory if publish will work correctly
+# It uses:
+# - verdaccio-auth-memory as in memory authentication
+# - verdaccio-memory as in memory storage
+# IMPORTANT: This configuration has too much security lacks to use in production.
+# Please, don't use it on production, only for testing purpose
+
+auth:
+  auth-memory:
+    users:
+      user:
+        name: user
+        password: test
+store:
+  memory:
+    limit: 200
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+packages:
+  '@*/*':
+    access: $all
+    publish: $authenticated
+    proxy: npmjs
+  '**':
+    access: $all
+    publish: $authenticated
+    proxy: npmjs


### PR DESCRIPTION


<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

Also, we need the scopes involved (aka package folder names):

eg:

-->
**Type:** ci
**Scope:** ci

The following has been addressed in the PR:

*  There is a related issue? **Part of #13**
*  Unit or Functional tests are included in the PR **No**

**Description:** Use Verdaccio with some plugins to test in-memory publish before real publish. These steps will only run when we try to publish, but we can improve in a future trying to use in each compilation (emulate a publish).

<!-- Resolves #??? -->
