### PR TITLE
chore: use Alpine image in DevContainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+# Verdaccio Monorepo VSCode DevContainer image
+#
+# To use Node Alpine image in VSCode DevContainers we need to add bash and git.
+# Also, as there are some dependencies that uses node-gyp, we have to add
+# support for it with tools like python, make and g++.
+
+FROM node:alpine
+
+RUN apk add --no-cache \
+    bash git \
+    g++ make python

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,33 +1,39 @@
 {
-	"name": "Verdaccio Monorepo (Node)",
-	"image": "node:latest",
+  "name": "Verdaccio Monorepo (Node)",
+  "dockerFile": "Dockerfile",
 
-	"runArgs": [ "-v", "${env:HOME}${env:USERPROFILE}/.ssh:/root/.ssh-localhost:ro" ],
+  "runArgs": [
+    "-v",
+    "${env:HOME}${env:USERPROFILE}/.ssh:/root/.ssh-localhost:ro"
+  ],
 
-	"settings":  {
-		"editor.rulers": [120],
-		"files.insertFinalNewline": true,
-		"files.trimFinalNewlines": true,
-		"files.trimTrailingWhitespace": true,
-		"eslint.autoFixOnSave": true,
-		"eslint.validate": [
-			"javascript",
-			"javascriptreact",
-			{ "language": "typescript", "autoFix": true },
-			{ "language": "typescriptreact", "autoFix": true },
-		],
-		"[markdown]": {
-			"files.trimTrailingWhitespace": false,
-		},
-	},
+  "settings": {
+    "editor.rulers": [120],
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true,
+    "files.trimTrailingWhitespace": true,
+    "eslint.autoFixOnSave": true,
+    "eslint.validate": [
+      "javascript",
+      "javascriptreact",
+      { "language": "typescript", "autoFix": true },
+      { "language": "typescriptreact", "autoFix": true }
+    ],
+    "[markdown]": {
+      "files.trimTrailingWhitespace": false
+    },
+    "[jsonc]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    }
+  },
 
-	"postCreateCommand": "mkdir -p ~/.ssh && cp -r ~/.ssh-localhost/* ~/.ssh && chmod 700 ~/.ssh && chmod 600 ~/.ssh/* && yarn install --frozen-lockfile",
+  "postCreateCommand": "mkdir -p ~/.ssh && cp -r ~/.ssh-localhost/* ~/.ssh && chmod 700 ~/.ssh && chmod 600 ~/.ssh/* && yarn install --frozen-lockfile",
 
-	"extensions": [
-		"editorconfig.editorconfig",
-		"dbaeumer.vscode-eslint",
-		"esbenp.prettier-vscode",
-		"visualstudioexptteam.vscodeintellicode",
-		"christian-kohler.path-intellisense",
-	],
+  "extensions": [
+    "editorconfig.editorconfig",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "visualstudioexptteam.vscodeintellicode",
+    "christian-kohler.path-intellisense"
+  ]
 }


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

Also, we need the scopes involved (aka package folder names):

eg:

-->
**Type:** chore
**Scope:** devcontainer

The following has been addressed in the PR:

*  There is a related issue? **No**
*  Unit or Functional tests are included in the PR **No**

**Description:** We have a simple configuration for VSCode Remote Development with the main things needed to develop in this repository. That configuration uses the main `node:latest` docker image, which size is 908MB after download.
In VSCode 1.38.0, the support for Alpine images has been included, so we can use it. The main difference is that `node:alpine` docker image doesn't include many tools we need, so we have to add them manually in a Dockerifle. The size of the base image is 80.3MB and, after installing those tools (git, bash, python, g++, make and dependencies), 289MB. 

<!-- Resolves #??? -->
