### PR TITLE
ci(github): improve naming and fix setup-node action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: push
 
 jobs:
-  build_test_lint:
+  ci:
     name: Node ${{ matrix.node_version }} and ${{ matrix.os }}
 
     strategy:
@@ -19,7 +19,7 @@ jobs:
     - name: Use Node ${{ matrix.node_version }}
       uses: actions/setup-node@v1
       with:
-        version: ${{ matrix.node_version }}
+        node_version: ${{ matrix.node_version }}
     - name: Install
       run: yarn install --frozen-lockfile
     - name: Build


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

Also, we need the scopes involved (aka package folder names):

eg:

-->
**Type:** ci
**Scope:** Github Actions

The following has been addressed in the PR:

*  There is a related issue? No
*  Unit or Functional tests are included in the PR No

**Description:** In [actions/setup-actions@v1.1.1](https://github.com/actions/setup-node/releases/tag/v1.1.1), version was deprecated in favor of node_version. Also, rename job and file to ci (to demostrate its purpose).

<!-- Resolves #??? -->
