### PR TITLE
Feature/remove ts ignores from aws s3 storage

### DIFF
--- a/plugins/aws-s3-storage/src/deleteKeyPrefix.ts
+++ b/plugins/aws-s3-storage/src/deleteKeyPrefix.ts
@@ -11,8 +11,9 @@ export function deleteKeyPrefix(s3: S3, options: DeleteKeyPrefixOptions, callbac
     if (err) {
       callback(convertS3Error(err));
     } else if (data.KeyCount) {
-      const objectsToDelete: S3.ObjectIdentifierList =
-        data.Contents !== undefined ? data.Contents.map(s3Object => ({ Key: s3Object.Key as S3.ObjectKey })) : [];
+      const objectsToDelete: S3.ObjectIdentifierList = data.Contents
+        ? data.Contents.map(s3Object => ({ Key: s3Object.Key as S3.ObjectKey }))
+        : [];
       s3.deleteObjects(
         {
           Bucket: options.Bucket,

--- a/plugins/aws-s3-storage/src/deleteKeyPrefix.ts
+++ b/plugins/aws-s3-storage/src/deleteKeyPrefix.ts
@@ -11,9 +11,8 @@ export function deleteKeyPrefix(s3: S3, options: DeleteKeyPrefixOptions, callbac
     if (err) {
       callback(convertS3Error(err));
     } else if (data.KeyCount) {
-      const objectsToDelete: S3.ObjectIdentifierList = data.Contents
-        ? data.Contents.map(s3Object => ({ Key: s3Object.Key as S3.ObjectKey }))
-        : [];
+      const objectsToDelete: S3.ObjectIdentifierList =
+        data.Contents !== undefined ? data.Contents.map(s3Object => ({ Key: s3Object.Key as S3.ObjectKey })) : [];
       s3.deleteObjects(
         {
           Bucket: options.Bucket,

--- a/plugins/aws-s3-storage/src/deleteKeyPrefix.ts
+++ b/plugins/aws-s3-storage/src/deleteKeyPrefix.ts
@@ -11,11 +11,12 @@ export function deleteKeyPrefix(s3: S3, options: DeleteKeyPrefixOptions, callbac
     if (err) {
       callback(convertS3Error(err));
     } else if (data.KeyCount) {
+      const objectsToDelete: S3.ObjectIdentifierList =
+        data.Contents !== undefined ? data.Contents.map(s3Object => ({ Key: s3Object.Key as S3.ObjectKey })) : [];
       s3.deleteObjects(
         {
           Bucket: options.Bucket,
-          // @ts-ignore
-          Delete: { Objects: data.Contents.map(({ Key }) => ({ Key })) },
+          Delete: { Objects: objectsToDelete },
         },
         err => {
           if (err) {

--- a/plugins/aws-s3-storage/src/s3PackageManager.ts
+++ b/plugins/aws-s3-storage/src/s3PackageManager.ts
@@ -112,19 +112,13 @@ export default class S3PackageManager implements ILocalPackageManager {
     );
   }
 
-  public removePackage(callback: Callback): void {
+  public removePackage(callback: (err: Error | null) => void): void {
     deleteKeyPrefix(
       this.s3,
       {
         Bucket: this.config.bucket,
         Prefix: `${this.config.keyPrefix}${this.packageName}`,
       },
-      /**
-       *  TODO: devinmotion: We could remove the ts-ignore with the following, but I am not sure whether this could break something outside:
-       *    (Breaking) change the function signature of the public remove Package
-       *    by changing type from Callback to more detailed (err: Error | null) => void
-       * */
-      // @ts-ignore
       callback
     );
   }

--- a/plugins/aws-s3-storage/src/s3PackageManager.ts
+++ b/plugins/aws-s3-storage/src/s3PackageManager.ts
@@ -79,7 +79,7 @@ export default class S3PackageManager implements ILocalPackageManager {
             reject(error);
             return;
           }
-          const body = response.Body !== undefined ? response.Body.toString() : '';
+          const body = response.Body ? response.Body.toString() : '';
           let data;
           try {
             data = JSON.parse(body);

--- a/plugins/aws-s3-storage/src/s3PackageManager.ts
+++ b/plugins/aws-s3-storage/src/s3PackageManager.ts
@@ -1,6 +1,6 @@
 import { S3, AWSError } from 'aws-sdk';
 import { UploadTarball, ReadTarball } from '@verdaccio/streams';
-import { HEADERS, HTTP_STATUS } from '@verdaccio/commons-api';
+import { HEADERS, HTTP_STATUS, VerdaccioError } from '@verdaccio/commons-api';
 import { Callback, Logger, Package, ILocalPackageManager } from '@verdaccio/types';
 import { is404Error, convertS3Error, create409Error } from './s3Errors';
 import { deleteKeyPrefix } from './deleteKeyPrefix';
@@ -79,7 +79,7 @@ export default class S3PackageManager implements ILocalPackageManager {
             reject(error);
             return;
           }
-          const body = response.Body !== undefined ? response.Body.toString() : '';
+          const body = response.Body ? response.Body.toString() : '';
           let data;
           try {
             data = JSON.parse(body);
@@ -123,7 +123,11 @@ export default class S3PackageManager implements ILocalPackageManager {
     );
   }
 
-  public createPackage(name: string, value: Package, callback: Function): void {
+  public createPackage(
+    name: string,
+    value: Package,
+    callback: (err: VerdaccioError, data?: S3.PutObjectOutput) => void
+  ): void {
     this.logger.debug(
       { name, packageName: this.packageName },
       's3: [S3PackageManager createPackage init] name @{name}/@{packageName}'
@@ -154,7 +158,11 @@ export default class S3PackageManager implements ILocalPackageManager {
     );
   }
 
-  public savePackage(name: string, value: Package, callback: Function): void {
+  public savePackage(
+    name: string,
+    value: Package,
+    callback: (err: VerdaccioError, data: S3.PutObjectOutput) => void
+  ): void {
     this.logger.debug(
       { name, packageName: this.packageName },
       's3: [S3PackageManager savePackage init] name @{name}/@{packageName}'
@@ -167,7 +175,6 @@ export default class S3PackageManager implements ILocalPackageManager {
         Bucket: this.config.bucket,
         Key: `${this.config.keyPrefix}${this.packageName}/${pkgFileName}`,
       },
-      // @ts-ignore
       callback
     );
   }

--- a/plugins/aws-s3-storage/src/s3PackageManager.ts
+++ b/plugins/aws-s3-storage/src/s3PackageManager.ts
@@ -119,6 +119,11 @@ export default class S3PackageManager implements ILocalPackageManager {
         Bucket: this.config.bucket,
         Prefix: `${this.config.keyPrefix}${this.packageName}`,
       },
+      /**
+       *  TODO: devinmotion: We could remove the ts-ignore with the following, but I am not sure whether this could break something outside:
+       *    (Breaking) change the function signature of the public remove Package
+       *    by changing type from Callback to more detailed (err: Error | null) => void
+       * */
       // @ts-ignore
       callback
     );

--- a/plugins/aws-s3-storage/src/s3PackageManager.ts
+++ b/plugins/aws-s3-storage/src/s3PackageManager.ts
@@ -1,6 +1,6 @@
 import { S3, AWSError } from 'aws-sdk';
 import { UploadTarball, ReadTarball } from '@verdaccio/streams';
-import { HEADERS, HTTP_STATUS, VerdaccioError } from '@verdaccio/commons-api';
+import { HEADERS, HTTP_STATUS } from '@verdaccio/commons-api';
 import { Callback, Logger, Package, ILocalPackageManager } from '@verdaccio/types';
 import { is404Error, convertS3Error, create409Error } from './s3Errors';
 import { deleteKeyPrefix } from './deleteKeyPrefix';
@@ -79,7 +79,7 @@ export default class S3PackageManager implements ILocalPackageManager {
             reject(error);
             return;
           }
-          const body = response.Body ? response.Body.toString() : '';
+          const body = response.Body !== undefined ? response.Body.toString() : '';
           let data;
           try {
             data = JSON.parse(body);
@@ -123,11 +123,7 @@ export default class S3PackageManager implements ILocalPackageManager {
     );
   }
 
-  public createPackage(
-    name: string,
-    value: Package,
-    callback: (err: VerdaccioError, data?: S3.PutObjectOutput) => void
-  ): void {
+  public createPackage(name: string, value: Package, callback: Function): void {
     this.logger.debug(
       { name, packageName: this.packageName },
       's3: [S3PackageManager createPackage init] name @{name}/@{packageName}'
@@ -158,11 +154,7 @@ export default class S3PackageManager implements ILocalPackageManager {
     );
   }
 
-  public savePackage(
-    name: string,
-    value: Package,
-    callback: (err: VerdaccioError, data: S3.PutObjectOutput) => void
-  ): void {
+  public savePackage(name: string, value: Package, callback: Function): void {
     this.logger.debug(
       { name, packageName: this.packageName },
       's3: [S3PackageManager savePackage init] name @{name}/@{packageName}'
@@ -175,6 +167,7 @@ export default class S3PackageManager implements ILocalPackageManager {
         Bucket: this.config.bucket,
         Key: `${this.config.keyPrefix}${this.packageName}/${pkgFileName}`,
       },
+      // @ts-ignore
       callback
     );
   }

--- a/plugins/aws-s3-storage/src/s3PackageManager.ts
+++ b/plugins/aws-s3-storage/src/s3PackageManager.ts
@@ -79,8 +79,7 @@ export default class S3PackageManager implements ILocalPackageManager {
             reject(error);
             return;
           }
-          // @ts-ignore
-          const body = response.Body.toString();
+          const body = response.Body !== undefined ? response.Body.toString() : '';
           let data;
           try {
             data = JSON.parse(body);


### PR DESCRIPTION
**Typings:**
**plugins\aws-s3-storage:**

The following has been addressed in the PR:

- In relation to general TypeScript improvements (https://github.com/verdaccio/verdaccio/issues/1461)

**Description:**

Tried to remove all 4 `ts-ignores` in plugin `aws-s3-storage`:
1. First one could be fixed by checking for undefined and returning empty array otherwise. Moreover needed to add TS as cast to map `string` back to `Key` alias
2. Second one could be fixed by checking response Body for undefined and returning empty string otherwise
3. Third one could be fixed by adding more detailed type (`Function` to `(err: Error | null) => void`). However this is a stricter type than before for the public method `removePackage`. I could not verify whether the method is used outside of this repository.
4. Last one could not be fixed without further implementation:
Expected detailed type in line 172 of `s3PackageManager.ts` in method `savePackage` is `AWSError`, however we are dealing with `VerdaccioError` at this moment. There has been a conversion from S3 to Verdaccio (`convertS3Error`). This typing and even functional problem may be solved by implementing back-conversion like e.g. `convertVerdaccioError`