### PR TITLE
fix(verdaccio-google-cloud): catch missing Secret on first run

### DIFF
--- a/plugins/google-cloud/src/data-storage.ts
+++ b/plugins/google-cloud/src/data-storage.ts
@@ -89,16 +89,26 @@ class GoogleCloudDatabase implements IPluginStorage<VerdaccioConfigGoogleStorage
     const key: Key = this.helper.datastore.key(['Secret', 'secret']);
     this.logger.debug('gcloud: [datastore getSecret] init');
 
-    return this.helper.datastore.get(key).then((data: object): string => {
-      this.logger.trace({ data }, 'gcloud: [datastore getSecret] response @{data}');
-      const entities = data[0];
-      if (!entities) {
-        // @ts-ignore
-        return null;
-      }
-      // "{\"secret\":\"181bc38698078f880564be1e4d7ec107ac8a3b344a924c6d86cea4a84a885ae0\"}"
-      return entities.secret;
-    });
+    return this.helper.datastore
+      .get(key)
+      .then((data: object): string => {
+        this.logger.trace({ data }, 'gcloud: [datastore getSecret] response @{data}');
+        const entities = data[0];
+        if (!entities) {
+          // @ts-ignore
+          return null;
+        }
+        // "{\"secret\":\"181bc38698078f880564be1e4d7ec107ac8a3b344a924c6d86cea4a84a885ae0\"}"
+        return entities.secret;
+      })
+      .catch(
+        (err: Error): Promise<string> => {
+          const error: VerdaccioError = getInternalError(err.message);
+
+          this.logger.warn({ error }, 'gcloud: [datastore getSecret] init error @{error}');
+          return Promise.reject(getServiceUnavailable('[getSecret] permissions error'));
+        }
+      );
   }
 
   public setSecret(secret: string): Promise<CommitResponse> {


### PR DESCRIPTION
in getSecret, if /Secret does not exist, we had an async
error uncaught. Catch it explicitly so that the Secret
will get created.

<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

Also, we need the scopes involved (aka package folder names):

eg:

-->
**Type:**
**Scope:**

The following has been addressed in the PR:

*  There is a related issue?
*  Unit or Functional tests are included in the PR

**Description:**

<!-- Resolves #??? -->
