### PR TITLE
fix: add allow_unpublish generic

### DIFF
--- a/core/types/index.d.ts
+++ b/core/types/index.d.ts
@@ -457,18 +457,19 @@ declare module '@verdaccio/types' {
     version?: string;
   }
 
+  type AuthAccessCallback = (error: string | null, access: boolean) => void;
   type AuthCallback = (error: string | null, groups: string[] | false) => void;
 
   interface IPluginAuth<T> extends IPlugin<T> {
     authenticate(user: string, password: string, cb: AuthCallback): void;
     adduser?(user: string, password: string, cb: AuthCallback): void;
     changePassword?(user: string, password: string, newPassword: string, cb: AuthCallback): void;
-    allow_publish?(user: RemoteUser, pkg: T & PackageAccess, cb: AuthCallback): void;
-    allow_access?(user: RemoteUser, pkg: T & PackageAccess, cb: AuthCallback): void;
-    allow_unpublish?(user: RemoteUser, pkg: T & PackageAccess, cb: AuthCallback): void;
-    allow_publish?(user: RemoteUser, pkg: AllowAccess & PackageAccess, cb: AuthCallback): void;
-    allow_access?(user: RemoteUser, pkg: AllowAccess & PackageAccess, cb: AuthCallback): void;
-    allow_unpublish?(user: RemoteUser, pkg: AllowAccess & PackageAccess, cb: AuthCallback): void;
+    allow_publish?(user: RemoteUser, pkg: T & PackageAccess, cb: AuthAccessCallback): void;
+    allow_access?(user: RemoteUser, pkg: T & PackageAccess, cb: AuthAccessCallback): void;
+    allow_unpublish?(user: RemoteUser, pkg: T & PackageAccess, cb: AuthAccessCallback): void;
+    allow_publish?(user: RemoteUser, pkg: AllowAccess & PackageAccess, cb: AuthAccessCallback): void;
+    allow_access?(user: RemoteUser, pkg: AllowAccess & PackageAccess, cb: AuthAccessCallback): void;
+    allow_unpublish?(user: RemoteUser, pkg: AllowAccess & PackageAccess, cb: AuthAccessCallback): void;
     apiJWTmiddleware?(helpers: any): Function;
   }
 

--- a/core/types/index.d.ts
+++ b/core/types/index.d.ts
@@ -6,6 +6,7 @@ declare module '@verdaccio/types' {
   type StorageList = string[];
   type Callback = Function;
   type CallbackError = (err: NodeJS.ErrnoException) => void;
+  type Test = string;
   interface Author {
     name: string;
     email?: string;

--- a/core/types/index.d.ts
+++ b/core/types/index.d.ts
@@ -6,7 +6,6 @@ declare module '@verdaccio/types' {
   type StorageList = string[];
   type Callback = Function;
   type CallbackError = (err: NodeJS.ErrnoException) => void;
-  type Test = string;
   interface Author {
     name: string;
     email?: string;

--- a/core/types/index.d.ts
+++ b/core/types/index.d.ts
@@ -463,11 +463,12 @@ declare module '@verdaccio/types' {
     authenticate(user: string, password: string, cb: AuthCallback): void;
     adduser?(user: string, password: string, cb: AuthCallback): void;
     changePassword?(user: string, password: string, newPassword: string, cb: AuthCallback): void;
-    allow_access?(user: RemoteUser, pkg: T & PackageAccess, cb: AuthCallback): void;
     allow_publish?(user: RemoteUser, pkg: T & PackageAccess, cb: AuthCallback): void;
-    allow_access?(user: RemoteUser, pkg: AllowAccess & PackageAccess, cb: AuthCallback): void;
     allow_publish?(user: RemoteUser, pkg: AllowAccess & PackageAccess, cb: AuthCallback): void;
+    allow_access?(user: RemoteUser, pkg: T & PackageAccess, cb: AuthCallback): void;
+    allow_access?(user: RemoteUser, pkg: AllowAccess & PackageAccess, cb: AuthCallback): void;
     allow_unpublish?(user: RemoteUser, pkg: AllowAccess & PackageAccess, cb: AuthCallback): void;
+    allow_unpublish?(user: RemoteUser, pkg: T & PackageAccess, cb: AuthCallback): void;
     apiJWTmiddleware?(helpers: any): Function;
   }
 

--- a/core/types/index.d.ts
+++ b/core/types/index.d.ts
@@ -464,11 +464,11 @@ declare module '@verdaccio/types' {
     adduser?(user: string, password: string, cb: AuthCallback): void;
     changePassword?(user: string, password: string, newPassword: string, cb: AuthCallback): void;
     allow_publish?(user: RemoteUser, pkg: T & PackageAccess, cb: AuthCallback): void;
-    allow_publish?(user: RemoteUser, pkg: AllowAccess & PackageAccess, cb: AuthCallback): void;
     allow_access?(user: RemoteUser, pkg: T & PackageAccess, cb: AuthCallback): void;
+    allow_unpublish?(user: RemoteUser, pkg: T & PackageAccess, cb: AuthCallback): void;
+    allow_publish?(user: RemoteUser, pkg: AllowAccess & PackageAccess, cb: AuthCallback): void;
     allow_access?(user: RemoteUser, pkg: AllowAccess & PackageAccess, cb: AuthCallback): void;
     allow_unpublish?(user: RemoteUser, pkg: AllowAccess & PackageAccess, cb: AuthCallback): void;
-    allow_unpublish?(user: RemoteUser, pkg: T & PackageAccess, cb: AuthCallback): void;
     apiJWTmiddleware?(helpers: any): Function;
   }
 


### PR DESCRIPTION
**Type:** bug
**Scope:** types

**Description:**

Add missing `allow_unpublish` generic interface

Add

```
  type AuthAccessCallback = (error: string | null, access: boolean) => void;
  type AuthCallback = (error: string | null, groups: string[] | false) => void;
```

The type `AuthAccessCallback` is intended to be more reliable in order to create plugins.