### PR TITLE
Allow endpoint to be configurable

### DIFF
--- a/plugins/aws-s3-storage/README.md
+++ b/plugins/aws-s3-storage/README.md
@@ -56,6 +56,7 @@ The configured values can either be the actual value or the name of an environme
 - `bucket`
 - `keyPrefix`
 - `region`
+- `endpoint`
 - `accessKeyID`
 - `secretAccessKey`
 
@@ -64,6 +65,7 @@ store:
   aws-s3-storage:
     bucket: S3_BUCKET # If an environment variable named S3_BUCKET is set, it will use that value. Otherwise assumes the bucket is named 'S3_BUCKET'
     keyPrefix: S3_KEY_PREFIX # If an environment variable named S3_KEY_PREFIX is set, it will use that value. Otherwise assumes the bucket is named 'S3_KEY_PREFIX'
+    endpoint: S3_ENDPOINT # If an environment variable named S3_ENDPOINT is set, it will use that value. Otherwise assumes the bucket is named 'S3_ENDPOINT'
     ...
 ```
 

--- a/plugins/aws-s3-storage/src/index.ts
+++ b/plugins/aws-s3-storage/src/index.ts
@@ -37,6 +37,7 @@ export default class S3Database implements IPluginStorage<S3Config> {
 
     this.config.bucket = setConfigValue(this.config.bucket);
     this.config.keyPrefix = setConfigValue(this.config.keyPrefix);
+    this.config.endpoint = setConfigValue(this.config.endpoint);
     this.config.region = setConfigValue(this.config.region);
     this.config.accessKeyId = setConfigValue(this.config.accessKeyId);
     this.config.secretAccessKey = setConfigValue(this.config.secretAccessKey);


### PR DESCRIPTION
Recently a new feature was introduced to allow passing the configuration values through environment variables only this didn't cover the `endpoint`-config this PR adds supports for defining the S3 Endpoint in the environment variables.