### PR TITLE
fix: resolve missing missing 'babel/proposal-optional-chaining' in test env

### DIFF
--- a/tools/babel-preset/lib/builder.js
+++ b/tools/babel-preset/lib/builder.js
@@ -52,7 +52,7 @@ module.exports = (api, opts, env, isPro) => {
       presets: defaultPresets(minNodeVersion)
         .concat(reactPreset)
         .concat(transpiler.presets),
-      plugins: defaultPlugins.concat(['babel-plugin-dynamic-import-node', 'emotion']),
+      plugins: defaultPlugins.concat(transpiler.plugins).concat(['babel-plugin-dynamic-import-node', 'emotion']),
     };
   } else if (env === 'docker') {
     return {


### PR DESCRIPTION
**Type:**
issue fix

**Scope:**
fixes missing babel typescript plugins in the `test` environment like `proposal-optional-chaining` which would fail verdaccio unit test if the syntax is used.