### PR TITLE
fix: restore Node v8 support

### DIFF
--- a/core/readme/package.json
+++ b/core/readme/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "dompurify": "2.0.8",
-    "jsdom": "16.2.1",
+    "jsdom": "15.2.1",
     "marked": "0.7.0"
   },
   "devDependencies": {

--- a/plugins/local-storage/package.json
+++ b/plugins/local-storage/package.json
@@ -37,7 +37,7 @@
     "async": "3.2.0",
     "level": "5.0.1",
     "lodash": "4.17.15",
-    "mkdirp": "1.0.3"
+    "mkdirp": "0.5.5"
   },
   "devDependencies": {
     "@types/minimatch": "^3.0.3",

--- a/plugins/local-storage/src/local-fs.ts
+++ b/plugins/local-storage/src/local-fs.ts
@@ -356,13 +356,12 @@ export default class LocalFS implements ILocalFSPackageManager {
 
     createTempFile(err => {
       if (err && err.code === noSuchFile) {
-        mkdirp(path.dirname(dest))
-          .then(() => {
-            createTempFile(cb);
-          })
-          .catch(err => {
+        mkdirp(path.dirname(dest), function(err) {
+          if (err) {
             return cb(err);
-          });
+          }
+          createTempFile(cb);
+        });
       } else {
         cb(err);
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8663,11 +8663,6 @@ mkdirp@*, mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.verdaccio.org/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
-  integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
-
 mocha@^7.1.0:
   version "7.1.0"
   resolved "https://registry.verdaccio.org/mocha/-/mocha-7.1.0.tgz#c784f579ad0904d29229ad6cb1e2514e4db7d249"


### PR DESCRIPTION
**Type:**  refactor
**Scope:** all

The following has been addressed in the PR:

*  There is a related issue?
*  Unit or Functional tests are included in the PR

**Description:**

this downgrade to dependencies (to fixed ones) and restore v8 support removed in previous releases.

Restore `mkdirp` and `jsdom`.

Resolves #355 


