### PR TITLE
feat: allow providing session token in config

### DIFF
--- a/plugins/aws-s3-storage/README.md
+++ b/plugins/aws-s3-storage/README.md
@@ -56,6 +56,7 @@ store:
     s3ForcePathStyle: false # optional, will use path style URLs for S3 objects
     accessKeyId: your-access-key-id # optional, aws accessKeyId for private S3 bucket
     secretAccessKey: your-secret-access-key # optional, aws secretAccessKey for private S3 bucket
+    sessionToken: your-session-token # optional, aws sessionToken for private S3 bucket
 ```
 
 The configured values can either be the actual value or the name of an environment variable that contains the value for the following options:
@@ -66,6 +67,7 @@ The configured values can either be the actual value or the name of an environme
 - `endpoint`
 - `accessKeyID`
 - `secretAccessKey`
+- `sessionToken`
 
 ``` yaml
 store:

--- a/plugins/aws-s3-storage/src/config.ts
+++ b/plugins/aws-s3-storage/src/config.ts
@@ -8,4 +8,5 @@ export interface S3Config extends Config {
   s3ForcePathStyle?: boolean;
   accessKeyId?: string;
   secretAccessKey?: string;
+  sessionToken?: string;
 }

--- a/plugins/aws-s3-storage/src/index.ts
+++ b/plugins/aws-s3-storage/src/index.ts
@@ -41,6 +41,7 @@ export default class S3Database implements IPluginStorage<S3Config> {
     this.config.region = setConfigValue(this.config.region);
     this.config.accessKeyId = setConfigValue(this.config.accessKeyId);
     this.config.secretAccessKey = setConfigValue(this.config.secretAccessKey);
+    this.config.sessionToken = setConfigValue(this.config.sessionToken);
 
     const configKeyPrefix = this.config.keyPrefix;
     this._localData = null;
@@ -54,6 +55,7 @@ export default class S3Database implements IPluginStorage<S3Config> {
       s3ForcePathStyle: this.config.s3ForcePathStyle,
       accessKeyId: this.config.accessKeyId,
       secretAccessKey: this.config.secretAccessKey,
+      sessionToken: this.config.sessionToken,
     });
   }
 

--- a/plugins/aws-s3-storage/src/s3PackageManager.ts
+++ b/plugins/aws-s3-storage/src/s3PackageManager.ts
@@ -22,15 +22,16 @@ export default class S3PackageManager implements ILocalPackageManager {
     this.config = config;
     this.packageName = packageName;
     this.logger = logger;
-    const { endpoint, region, s3ForcePathStyle, accessKeyId, secretAccessKey } = config;
+    const { endpoint, region, s3ForcePathStyle, accessKeyId, secretAccessKey, sessionToken } = config;
 
-    this.s3 = new S3({ endpoint, region, s3ForcePathStyle, accessKeyId, secretAccessKey });
+    this.s3 = new S3({ endpoint, region, s3ForcePathStyle, accessKeyId, secretAccessKey, sessionToken });
     this.logger.trace({ packageName }, 's3: [S3PackageManager constructor] packageName @{packageName}');
     this.logger.trace({ endpoint }, 's3: [S3PackageManager constructor] endpoint @{endpoint}');
     this.logger.trace({ region }, 's3: [S3PackageManager constructor] region @{region}');
     this.logger.trace({ s3ForcePathStyle }, 's3: [S3PackageManager constructor] s3ForcePathStyle @{s3ForcePathStyle}');
     this.logger.trace({ accessKeyId }, 's3: [S3PackageManager constructor] accessKeyId @{accessKeyId}');
     this.logger.trace({ secretAccessKey }, 's3: [S3PackageManager constructor] secretAccessKey @{secretAccessKey}');
+    this.logger.trace({ sessionToken }, 's3: [S3PackageManager constructor] sessionToken @{sessionToken}');
 
     const packageAccess = this.config.getMatchedPackagesSpec(packageName);
     if (packageAccess) {

--- a/plugins/aws-s3-storage/tests/setConfigValue.test.ts
+++ b/plugins/aws-s3-storage/tests/setConfigValue.test.ts
@@ -3,6 +3,7 @@ import setConfigValue from '../src/setConfigValue';
 describe('Setting config values', () => {
   const bucket = 'TEST_AWS_S3_BUCKET_NAME';
   const keyPrefix = 'TEST_AWS_S3_BUCKET_PREFIX';
+  const sessionToken = 'TEST_AWS_S3_SESSION_TOKEN';
 
   afterEach(async () => {
     delete process.env[bucket];
@@ -20,6 +21,15 @@ describe('Setting config values', () => {
     const expected = 'someBucket';
     process.env[bucket] = expected;
     const actual = setConfigValue(bucket);
+
+    expect(actual === expected).toBeTruthy();
+  });
+
+  // Session token is temporary and users will mostly set it as environment variable. Verify.
+  test('should use the environment variable value for session token', async () => {
+    const expected = 'mySessionToken';
+    process.env[sessionToken] = expected;
+    const actual = setConfigValue(sessionToken);
 
     expect(actual === expected).toBeTruthy();
   });


### PR DESCRIPTION
**Type:Feature**
**Scope:aws-s3-storage**

The following has been addressed in the PR:

Ability to provide session token when connecting to private s3 bucket.

*  There is a related issue? 
No.
*  Unit or Functional tests are not included in the PR
No, looked at the existing unit tests. This is only adding a value to the config and I don't see any tests checking each config value. Please advice if I need to add tests.

**Description:**
Sometimes session tokens are required to be able to connect. Adding the ability to add session token to config.
