### PR TITLE
fix: exclude ending of pipe for verdaccio/verdaccio/issues/1866

### DIFF
--- a/plugins/audit/src/audit.ts
+++ b/plugins/audit/src/audit.ts
@@ -29,7 +29,7 @@ export default class ProxyAudit implements IPluginMiddleware<ConfigAudit> {
       };
 
       req
-        .pipe(request(requestOptions))
+        .pipe(request(requestOptions), { end: false })
         .on('error', err => {
           if (typeof res.report_error === 'function') {
             return res.report_error(err);


### PR DESCRIPTION
**Type: bug**
**Scope: audit**

The following has been addressed in the PR:

*  There is a related issue? [verdaccio/verdaccio/issues/1866](https://github.com/verdaccio/verdaccio/issues/1866)
*  Unit or Functional tests are included in the PR? - No change

**Description:**
After merging [verdaccio/verdaccio/#1841](https://github.com/verdaccio/verdaccio/pull/1841) we have some problems with working of the audit plugin:
```
> npm audit
npm ERR! code ENOAUDIT
npm ERR! audit Your configured registry (PRIVATE-VERDACCIO-REGISTRY) does not support audit requests, or the audit endpoint is temporarily unavailable.

npm ERR! A complete log of this run can be found in:
npm ERR! /Users/**
```
We've found a [similar problem](https://github.com/expressjs/body-parser/issues/94#issuecomment-95951093) in the ExpressJS issues: 
`You can only read a stream one time in Node.js. req was already read into req.body by this module, so your req.pipe is what's hanging`

<!-- Resolves #??? -->
Add configuration which will disable ending of pipe (`{ end: false}`)