### PR TITLE
Fix the prefix used to delete from s3 when unpublishing packages

### DIFF
--- a/.changeset/curly-cherries-glow.md
+++ b/.changeset/curly-cherries-glow.md
@@ -1,0 +1,5 @@
+---
+'verdaccio-aws-s3-storage': patch
+---
+
+Fix the prefix used to delete from s3 when unpublishing packages

--- a/plugins/aws-s3-storage/src/s3PackageManager.ts
+++ b/plugins/aws-s3-storage/src/s3PackageManager.ts
@@ -133,7 +133,7 @@ export default class S3PackageManager implements ILocalPackageManager {
       this.s3,
       {
         Bucket: this.config.bucket,
-        Prefix: `${this.packagePath}`,
+        Prefix: addTrailingSlash(this.packagePath),
       },
       function(err) {
         if (err && is404Error(err as VerdaccioError)) {

--- a/plugins/aws-s3-storage/tests/s3PackageManagerMockedS3.test.ts
+++ b/plugins/aws-s3-storage/tests/s3PackageManagerMockedS3.test.ts
@@ -231,7 +231,7 @@ describe('S3PackageManager with mocked s3', function() {
       expect(mockListObject).toHaveBeenCalledWith(
         {
           Bucket: 'test-bucket',
-          Prefix: 'testKeyPrefix/@company/test-package',
+          Prefix: 'testKeyPrefix/@company/test-package/',
         },
         expect.any(Function)
       );
@@ -270,7 +270,7 @@ describe('S3PackageManager with mocked s3', function() {
       expect(mockListObject).toHaveBeenCalledWith(
         {
           Bucket: 'test-bucket',
-          Prefix: 'testKeyPrefix/customFolder/@company/test-package',
+          Prefix: 'testKeyPrefix/customFolder/@company/test-package/',
         },
         expect.any(Function)
       );


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

Also, we need the scopes involved (aka package folder names):

eg:

-->
**Type: Bug
**Scope: plugins/aws-s3-storage

**Description:**

This PR resolves [this issue ](https://github.com/verdaccio/verdaccio/issues/1984). 

The PR add trailing slashes to the prefix of listobjects when removing a package. This is maded to not match more packages than it should. 
