### PR TITLE
feat: parseReadme pathname option

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "master",
+  "baseBranch": "9.x",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.changeset/happy-lies-pretend.md
+++ b/.changeset/happy-lies-pretend.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/readme': minor
+---
+
+Added optional options object param to parseReadme where {pathname: string} can define the pathname to use when resolving anchor links by pre-padding the pathname to the anchor link.
+Helps to resolve verdaccio/verdaccio#2712

--- a/core/readme/src/index.ts
+++ b/core/readme/src/index.ts
@@ -4,14 +4,21 @@ import { JSDOM } from 'jsdom';
 
 const DOMPurify = createDOMPurify(new JSDOM('').window);
 
-export default function parseReadme(readme: string): string | void {
+export default function parseReadme(readme: string,
+                                    options: { pathname?: string | void } = {}): string | void {
+  let result;
+
   if (readme) {
-    return DOMPurify.sanitize(
+    result = DOMPurify.sanitize(
       marked(readme, {
         sanitize: false,
       }).trim()
     );
+
+    if ('string' === typeof options.pathname) {
+      result = result.replace(/href="#/gi, `href="${options.pathname}#`);
+    }
   }
 
-  return;
+  return result;
 }

--- a/core/readme/tests/readme.spec.ts
+++ b/core/readme/tests/readme.spec.ts
@@ -37,6 +37,10 @@ describe('readme', () => {
       expect(parseReadme('# hi')).toEqual(`<h1 id=\"hi\">hi</h1>`);
     });
 
+    test('should parse anchor ref with pathname', () => {
+      expect(parseReadme("[Test](#test)", {pathname:'/-/web/detail/@reg/pack'})).toEqual('<p><a href="/-/web/detail/@reg/pack#test">Test</a></p>');
+    });
+
     test('should parse basic / js alert', () => {
       expect(parseReadme("[Basic](javascript:alert('Basic'))")).toEqual('<p><a>Basic</a></p>');
     });


### PR DESCRIPTION
**Description:**

Added optional options object param to `parseReadme` where `{pathname: string}` can define the `pathname` to use when resolving anchor links by pre-padding the `pathname` to the anchor link.

Helps to resolve https://github.com/verdaccio/verdaccio/issues/2712
