### PR TITLE
fix: Fix storing same named files from different pkgs in memory plugin

### DIFF
--- a/.changeset/cold-files-drop.md
+++ b/.changeset/cold-files-drop.md
@@ -1,0 +1,5 @@
+---
+'verdaccio-memory': patch
+---
+
+Fix storing tarballs with identical names from different packages in memory plugin

--- a/plugins/memory/test/memory.spec.ts
+++ b/plugins/memory/test/memory.spec.ts
@@ -264,7 +264,47 @@ describe('memory unit test .', () => {
         }
       });
 
-      test('should read a tarball', done => {
+      test('should support writting identical tarball filenames from different packages', done => {
+        const localMemory: IPluginStorage<ConfigMemory> = new LocalMemory(config, defaultConfig);
+        const pkgName1 = 'package1';
+        const pkgName2 = 'package2';
+        const filename = 'tarball-3.0.0.tgz';
+        const dataTarball1 = '12345';
+        const dataTarball2 = '12345678';
+        const handler = localMemory.getPackageStorage(pkgName1);
+        if (handler) {
+          const stream = handler.writeTarball(filename);
+          stream.on('data', data => {
+            expect(data.toString()).toBe(dataTarball1);
+          });
+          stream.on('open', () => {
+            stream.done();
+            stream.end();
+          });
+          stream.on('success', () => {
+            const handler = localMemory.getPackageStorage(pkgName2);
+            if (handler) {
+              const stream = handler.writeTarball(filename);
+              stream.on('data', data => {
+                expect(data.toString()).toBe(dataTarball2);
+              });
+              stream.on('open', () => {
+                stream.done();
+                stream.end();
+              });
+              stream.on('success', () => {
+                done();
+              });
+
+              stream.write(dataTarball2);
+            }
+          });
+
+          stream.write(dataTarball1);
+        }
+      });
+
+      test('should read a tarball', (done) => {
         const localMemory: IPluginStorage<ConfigMemory> = new LocalMemory(config, defaultConfig);
         const pkgName = 'test.tar.gz';
         const dataTarball = '12345';


### PR DESCRIPTION
**Type:** bug
**Scope:** memory plugin

**Description:**

The memory plugin was not correctly writing tarballs that have the same name but are from different packages and have different content.

Backport of https://github.com/verdaccio/verdaccio/pull/3200
