### PR TITLE
feat: allow other password hashing algorithms

### DIFF
--- a/.changeset/tough-turtles-matter.md
+++ b/.changeset/tough-turtles-matter.md
@@ -1,0 +1,36 @@
+---
+'verdaccio-htpasswd': minor
+---
+
+feat: allow other password hashing algorithms
+
+copied from v6 plugins by @greshilov https://github.com/verdaccio/verdaccio/pull/2072
+
+> To avoid a breaking change, the default algorithm is `crypt`.
+
+### Context
+
+The current implementation of the `htpasswd` module supports multiple hash formats on verify, but only `crypt` on sign in.
+`crypt` is an insecure old format, so to improve the security of the new `verdaccio` release we introduce the support of multiple hash algorithms on sign in step.
+
+### New hashing algorithms
+
+The new possible hash algorithms to use are `bcrypt`, `md5`, `sha1`. `bcrypt` is chosen as a default, because of its customizable complexity and overall reliability. You can read more about them [here](https://httpd.apache.org/docs/2.4/misc/password_encryptions.html).
+
+Two new properties are added to `auth` section in the configuration file:
+
+- `algorithm` to choose the way you want to hash passwords.
+- `rounds` is used to determine `bcrypt` complexity. So one can improve security according to increasing computational power.
+
+Example of the new `auth` config file section:
+
+```yaml
+auth:
+htpasswd:
+  file: ./htpasswd
+  max_users: 1000
+  # Hash algorithm, possible options are: "bcrypt", "md5", "sha1", "crypt".
+  algorithm: bcrypt
+  # Rounds number for "bcrypt", will be ignored for other algorithms.
+  rounds: 10
+```

--- a/.changeset/tough-turtles-matter.md
+++ b/.changeset/tough-turtles-matter.md
@@ -15,7 +15,7 @@ The current implementation of the `htpasswd` module supports multiple hash forma
 
 ### New hashing algorithms
 
-The new possible hash algorithms to use are `bcrypt`, `md5`, `sha1`. `bcrypt` is chosen as a default, because of its customizable complexity and overall reliability. You can read more about them [here](https://httpd.apache.org/docs/2.4/misc/password_encryptions.html).
+The new possible hash algorithms to use are `bcrypt`, `md5`, `sha1`. You can read more about them [here](https://httpd.apache.org/docs/2.4/misc/password_encryptions.html).
 
 Two new properties are added to `auth` section in the configuration file:
 

--- a/plugins/htpasswd/README.md
+++ b/plugins/htpasswd/README.md
@@ -11,7 +11,7 @@
 
 `verdaccio-htpasswd` is a default authentication plugin for the [Verdaccio](https://github.com/verdaccio/verdaccio).
 
-> This plugin is being used as dependency after `v3.0.0-beta.x`. The `v2.x` still contains this plugin built-in.
+> Plugin only valid for verdaccio v5.x
 
 ## Install
 
@@ -27,8 +27,30 @@ As simple as running:
             # Maximum amount of users allowed to register, defaults to "+infinity".
             # You can set this to -1 to disable registration.
             #max_users: 1000
+            # Hash algorithm, possible options are: "bcrypt", "md5", "sha1", "crypt".
+            # Default algorithm is crypt.
+            #algorithm: bcrypt
+            # Rounds number for "bcrypt", will be ignored for other algorithms.
+            # Setting this value higher will result in password verification taking longer.
+            #rounds: 10
             # Log a warning if the password takes more then this duration in milliseconds to verify.
             #slow_verify_ms: 200
+
+### Bcrypt rounds
+
+It is important to note that when using the default `bcrypt` algorithm and setting
+the `rounds` configuration value to a higher number then the default of `10`, that
+verification of a user password can cause significantly increased CPU usage and
+additional latency in processing requests.
+
+If your Verdaccio instance handles a large number of authenticated requests using
+username and password for authentication, the `rounds` configuration value may need
+to be decreased to prevent excessive CPU usage and request latency.
+
+Also note that setting the `rounds` configuration value to a value that is too small
+increases the risk of successful brute force attack. Auth0 has a
+[blog article](https://auth0.com/blog/hashing-in-action-understanding-bcrypt)
+that provides an overview of how `bcrypt` hashing works and some best practices.
 
 ## Logging In
 
@@ -49,13 +71,7 @@ file.
 
 The htpasswd file contains rows corresponding to a pair of username and password
 separated with a colon character. The password is encrypted using the UNIX system's
-crypt method and may use MD5 or SHA1.
-
-## Plugin Development in Verdaccio
-
-There are many ways to extend [Verdaccio](https://github.com/verdaccio/verdaccio),
-currently it support authentication plugins, middleware plugins (since v2.7.0)
-and storage plugins since (v3.x).
+`crypt` method and may use MD5 or SHA1.
 
 #### Useful Links
 

--- a/plugins/htpasswd/package.json
+++ b/plugins/htpasswd/package.json
@@ -35,8 +35,9 @@
     "unix-crypt-td-js": "1.1.4"
   },
   "devDependencies": {
-    "@types/bcryptjs": "^2.4.2",
-    "@verdaccio/types": "workspace:10.5.1"
+    "@types/bcryptjs": "2.4.2",
+    "@verdaccio/types": "workspace:10.5.1",
+    "mockdate": "3.0.2"
   },
   "scripts": {
     "clean": "rimraf ./build",

--- a/plugins/htpasswd/src/crypt3.ts
+++ b/plugins/htpasswd/src/crypt3.ts
@@ -10,28 +10,37 @@ import crypto from 'crypto';
 
 import crypt from 'unix-crypt-td-js';
 
+export enum EncryptionMethod {
+  md5 = 'md5',
+  sha1 = 'sha1',
+  crypt = 'crypt',
+  blowfish = 'blowfish',
+  sha256 = 'sha256',
+  sha512 = 'sha512',
+}
+
 /**
  * Create salt
- * @param {string} type The type of salt: md5, blowfish (only some linux
+ * @param {EncryptionMethod} type The type of salt: md5, blowfish (only some linux
  * distros), sha256 or sha512. Default is sha512.
  * @returns {string} Generated salt string
  */
-export function createSalt(type = 'crypt'): string {
+export function createSalt(type: EncryptionMethod = EncryptionMethod.crypt): string {
   switch (type) {
-    case 'crypt':
+    case EncryptionMethod.crypt:
       // Legacy crypt salt with no prefix (only the first 2 bytes will be used).
       return crypto.randomBytes(2).toString('base64');
 
-    case 'md5':
+    case EncryptionMethod.md5:
       return '$1$' + crypto.randomBytes(10).toString('base64');
 
-    case 'blowfish':
+    case EncryptionMethod.blowfish:
       return '$2a$' + crypto.randomBytes(10).toString('base64');
 
-    case 'sha256':
+    case EncryptionMethod.sha256:
       return '$5$' + crypto.randomBytes(10).toString('base64');
 
-    case 'sha512':
+    case EncryptionMethod.sha512:
       return '$6$' + crypto.randomBytes(10).toString('base64');
 
     default:

--- a/plugins/htpasswd/src/htpasswd.ts
+++ b/plugins/htpasswd/src/htpasswd.ts
@@ -60,6 +60,10 @@ export default class HTPasswd implements IPluginAuth<HTPasswdConfig> {
       // of this plugin uses bcrypt by default
       // https://github.com/verdaccio/verdaccio/pull/2072#issuecomment-770235502
       algorithm = HtpasswdHashAlgorithm.crypt;
+      this.logger.warn(
+        // eslint-disable-next-line max-len
+        '"crypt" algorithm is deprecated consider switch to "bcrypt". Read more: https://github.com/verdaccio/monorepo/pull/580'
+      );
     } else if (HtpasswdHashAlgorithm[config.algorithm] !== undefined) {
       algorithm = HtpasswdHashAlgorithm[config.algorithm];
     } else {

--- a/plugins/htpasswd/src/htpasswd.ts
+++ b/plugins/htpasswd/src/htpasswd.ts
@@ -45,7 +45,6 @@ export default class HTPasswd implements IPluginAuth<HTPasswdConfig> {
   // constructor
   public constructor(config: AuthConf, options: PluginOptions<HTPasswdConfig>) {
     this.users = {};
-
     // verdaccio logger
     this.logger = options.logger;
 
@@ -70,6 +69,13 @@ export default class HTPasswd implements IPluginAuth<HTPasswdConfig> {
       throw new Error(`Invalid algorithm "${config.algorithm}"`);
     }
 
+    this.lastTime = null;
+
+    const { file } = config;
+    if (!file) {
+      throw new Error('should specify "file" in config');
+    }
+
     if (algorithm === HtpasswdHashAlgorithm.bcrypt) {
       rounds = config.rounds || DEFAULT_BCRYPT_ROUNDS;
     } else if (config.rounds !== undefined) {
@@ -80,14 +86,6 @@ export default class HTPasswd implements IPluginAuth<HTPasswdConfig> {
       algorithm,
       rounds,
     };
-
-    this.lastTime = null;
-
-    const { file } = config;
-
-    if (!file) {
-      throw new Error('should specify "file" in config');
-    }
 
     this.path = Path.resolve(Path.dirname(options.config.self_path), file);
     this.slowVerifyMs = config.slow_verify_ms || DEFAULT_SLOW_VERIFY_MS;

--- a/plugins/htpasswd/src/index.ts
+++ b/plugins/htpasswd/src/index.ts
@@ -1,4 +1,4 @@
-import HTPasswd from './htpasswd';
+import HTPasswd, { HTPasswdConfig } from './htpasswd';
 
 /**
  * A new instance of HTPasswd class.
@@ -6,6 +6,8 @@ import HTPasswd from './htpasswd';
  * @param {object} stuff
  * @returns {object}
  */
-export default function(config, stuff): HTPasswd {
+export default function (config, stuff): HTPasswd {
   return new HTPasswd(config, stuff);
 }
+
+export { HTPasswd, HTPasswdConfig };

--- a/plugins/htpasswd/tests/__snapshots__/utils.test.ts.snap
+++ b/plugins/htpasswd/tests/__snapshots__/utils.test.ts.snap
@@ -1,17 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`addUserToHTPasswd - crypt3 should add new htpasswd to the end 1`] = `
+exports[`addUserToHTPasswd - bcrypt should add new htpasswd to the end 1`] = `
+"username:$2a$10$......................7zqaLmaKtn.i7IjPfuPGY2Ah/mNM6Sy:autocreated 2018-01-14T11:17:40.712Z
+"
+`;
+
+exports[`addUserToHTPasswd - bcrypt should add new htpasswd to the end in multiline input 1`] = `
+"test1:$6b9MlB3WUELU:autocreated 2017-11-06T18:17:21.957Z
+    test2:$6FrCaT/v0dwE:autocreated 2017-12-14T13:30:20.838Z
+username:$2a$10$......................7zqaLmaKtn.i7IjPfuPGY2Ah/mNM6Sy:autocreated 2018-01-14T11:17:40.712Z
+"
+`;
+
+exports[`addUserToHTPasswd - bcrypt should throw an error for incorrect username with space 1`] = `"username should not contain non-uri-safe characters"`;
+
+exports[`changePasswordToHTPasswd should change the password 1`] = `
+"root:$2a$10$......................0qqDmeqkAfPx68M2ArX8hVzcVNft5Ha:autocreated 2018-01-14T11:17:40.712Z
+"
+`;
+
+exports[`generateHtpasswdLine should correctly generate line for bcrypt 1`] = `
+"username:$2a$04$......................LAtw7/ohmmBAhnXqmkuIz83Rl5Qdjhm:autocreated 2018-01-14T11:17:40.712Z
+"
+`;
+
+exports[`generateHtpasswdLine should correctly generate line for crypt 1`] = `
 "username:$66to3JK5RgZM:autocreated 2018-01-14T11:17:40.712Z
 "
 `;
 
-exports[`addUserToHTPasswd - crypt3 should add new htpasswd to the end in multiline input 1`] = `
-"test1:$6b9MlB3WUELU:autocreated 2017-11-06T18:17:21.957Z
-    test2:$6FrCaT/v0dwE:autocreated 2017-12-14T13:30:20.838Z
-username:$66to3JK5RgZM:autocreated 2018-01-14T11:17:40.712Z
+exports[`generateHtpasswdLine should correctly generate line for md5 1`] = `
+"username:$apr1$MMMMMMMM$2lGUwLC3NFfN74jH51z1W.:autocreated 2018-01-14T11:17:40.712Z
 "
 `;
 
-exports[`addUserToHTPasswd - crypt3 should throw an error for incorrect username with space 1`] = `"username should not contain non-uri-safe characters"`;
-
-exports[`changePasswordToHTPasswd should change the password 1`] = `"root:$6JaJqI5HUf.Q:autocreated 2018-08-20T13:38:12.164Z"`;
+exports[`generateHtpasswdLine should correctly generate line for sha1 1`] = `
+"username:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=:autocreated 2018-01-14T11:17:40.712Z
+"
+`;

--- a/plugins/htpasswd/tests/crypt3.test.ts
+++ b/plugins/htpasswd/tests/crypt3.test.ts
@@ -1,10 +1,10 @@
-import { createSalt } from '../src/crypt3';
+import { createSalt, EncryptionMethod } from '../src/crypt3';
 
 jest.mock('crypto', () => {
   return {
-    randomBytes: (): { toString: () => string } => {
+    randomBytes: (len: number): { toString: () => string } => {
       return {
-        toString: (): string => '/UEGzD0RxSNDZA==',
+        toString: (): string => '/UEGzD0RxSNDZA=='.substring(0, len),
       };
     },
   };
@@ -12,20 +12,20 @@ jest.mock('crypto', () => {
 
 describe('createSalt', () => {
   test('should match with the correct salt type', () => {
-    expect(createSalt('crypt')).toEqual('/UEGzD0RxSNDZA==');
-    expect(createSalt('md5')).toEqual('$1$/UEGzD0RxSNDZA==');
-    expect(createSalt('blowfish')).toEqual('$2a$/UEGzD0RxSNDZA==');
-    expect(createSalt('sha256')).toEqual('$5$/UEGzD0RxSNDZA==');
-    expect(createSalt('sha512')).toEqual('$6$/UEGzD0RxSNDZA==');
+    expect(createSalt(EncryptionMethod.crypt)).toEqual('/U');
+    expect(createSalt(EncryptionMethod.md5)).toEqual('$1$/UEGzD0RxS');
+    expect(createSalt(EncryptionMethod.blowfish)).toEqual('$2a$/UEGzD0RxS');
+    expect(createSalt(EncryptionMethod.sha256)).toEqual('$5$/UEGzD0RxS');
+    expect(createSalt(EncryptionMethod.sha512)).toEqual('$6$/UEGzD0RxS');
   });
 
   test('should fails on unkwon type', () => {
-    expect(function() {
-      createSalt('bad');
+    expect(function () {
+      createSalt('bad' as any);
     }).toThrow(/Unknown salt type at crypt3.createSalt: bad/);
   });
 
   test('should generate legacy crypt salt by default', () => {
-    expect(createSalt()).toEqual(createSalt('crypt'));
+    expect(createSalt()).toEqual(createSalt(EncryptionMethod.crypt));
   });
 });

--- a/plugins/htpasswd/tests/htpasswd.test.ts
+++ b/plugins/htpasswd/tests/htpasswd.test.ts
@@ -37,7 +37,10 @@ describe('HTPasswd', () => {
   });
 
   describe('constructor()', () => {
-    const emptyPluginOptions = { config: {} } as any as PluginOptions<HTPasswdConfig>;
+    const emptyPluginOptions = {
+      config: {},
+      logger: { warn: jest.fn() },
+    } as any as PluginOptions<HTPasswdConfig>;
 
     test('should ensure file path configuration exists', () => {
       expect(function () {
@@ -47,7 +50,6 @@ describe('HTPasswd', () => {
 
     test('should throw error about incorrect algorithm', () => {
       expect(function () {
-        // @ts-expect-error
         let invalidConfig = { algorithm: 'invalid', ...config } as HTPasswdConfig;
         new HTPasswd(invalidConfig, emptyPluginOptions);
       }).toThrow(/Invalid algorithm "invalid"/);

--- a/plugins/htpasswd/tests/htpasswd.test.ts
+++ b/plugins/htpasswd/tests/htpasswd.test.ts
@@ -105,7 +105,7 @@ describe('HTPasswd', () => {
         done();
       };
       wrapper.authenticate('bcrypt', 'password', callback);
-    }, 15000);
+    }, 18000);
   });
 
   describe('addUser()', () => {
@@ -141,7 +141,10 @@ describe('HTPasswd', () => {
       test('sanityCheck should return an Error', (done) => {
         jest.doMock('../src/utils.ts', () => {
           return {
-            sanityCheck: (): Error => Error('some error'),
+            sanityCheck: () =>
+              new Promise(() => {
+                throw Error('some error');
+              }),
             HtpasswdHashAlgorithm,
           };
         });
@@ -158,7 +161,7 @@ describe('HTPasswd', () => {
       test('lockAndRead should return an Error', (done) => {
         jest.doMock('../src/utils.ts', () => {
           return {
-            sanityCheck: (): any => null,
+            sanityCheck: () => Promise.resolve(null),
             lockAndRead: (_a, b): any => b(new Error('lock error')),
             HtpasswdHashAlgorithm,
           };
@@ -176,7 +179,7 @@ describe('HTPasswd', () => {
       test('addUserToHTPasswd should return an Error', (done) => {
         jest.doMock('../src/utils.ts', () => {
           return {
-            sanityCheck: (): any => null,
+            sanityCheck: () => Promise.resolve(null),
             parseHTPasswd: (): void => {},
             lockAndRead: (_a, b): any => b(null, ''),
             unlockFile: (_a, b): any => b(),
@@ -194,7 +197,7 @@ describe('HTPasswd', () => {
       test('writeFile should return an Error', (done) => {
         jest.doMock('../src/utils.ts', () => {
           return {
-            sanityCheck: (): any => null,
+            sanityCheck: () => Promise.resolve(null),
             parseHTPasswd: (): void => {},
             lockAndRead: (_a, b): any => b(null, ''),
             addUserToHTPasswd: (): void => {},

--- a/plugins/htpasswd/tests/utils.test.ts
+++ b/plugins/htpasswd/tests/utils.test.ts
@@ -1,17 +1,36 @@
+// @ts-ignore: Module has no default export
 import crypto from 'crypto';
+import MockDate from 'mockdate';
 
+import { DEFAULT_BCRYPT_ROUNDS } from '../src/htpasswd';
 import {
-  verifyPassword,
+  HtpasswdHashAlgorithm,
+  addUserToHTPasswd,
+  changePasswordToHTPasswd,
+  generateHtpasswdLine,
   lockAndRead,
   parseHTPasswd,
-  addUserToHTPasswd,
   sanityCheck,
-  changePasswordToHTPasswd,
-  getCryptoPassword,
+  verifyPassword,
 } from '../src/utils';
 
 const mockReadFile = jest.fn();
 const mockUnlockFile = jest.fn();
+
+const defaultHashConfig = {
+  algorithm: HtpasswdHashAlgorithm.bcrypt,
+  rounds: DEFAULT_BCRYPT_ROUNDS,
+};
+
+const mockTimeAndRandomBytes = () => {
+  MockDate.set('2018-01-14T11:17:40.712Z');
+  crypto.randomBytes = jest.fn(() => {
+    return {
+      toString: (): string => '$6',
+    };
+  });
+  Math.random = jest.fn(() => 0.38849);
+};
 
 jest.mock('@verdaccio/file-locking', () => ({
   readFile: () => mockReadFile(),
@@ -85,51 +104,53 @@ describe('verifyPassword', () => {
   });
 });
 
-describe('addUserToHTPasswd - crypt3', () => {
-  beforeAll(() => {
-    // @ts-ignore
-    global.Date = jest.fn(() => {
-      return {
-        parse: jest.fn(),
-        toJSON: (): string => '2018-01-14T11:17:40.712Z',
-      };
-    });
+describe('generateHtpasswdLine', () => {
+  beforeAll(mockTimeAndRandomBytes);
 
-    crypto.randomBytes = jest.fn(() => {
-      return {
-        toString: (): string => '$6',
-      };
-    });
+  const [user, passwd] = ['username', 'password'];
+
+  it('should correctly generate line for md5', () => {
+    const md5Conf = { algorithm: HtpasswdHashAlgorithm.md5 };
+    expect(generateHtpasswdLine(user, passwd, md5Conf)).toMatchSnapshot();
   });
+
+  it('should correctly generate line for sha1', () => {
+    const sha1Conf = { algorithm: HtpasswdHashAlgorithm.sha1 };
+    expect(generateHtpasswdLine(user, passwd, sha1Conf)).toMatchSnapshot();
+  });
+
+  it('should correctly generate line for crypt', () => {
+    const cryptConf = { algorithm: HtpasswdHashAlgorithm.crypt };
+    expect(generateHtpasswdLine(user, passwd, cryptConf)).toMatchSnapshot();
+  });
+
+  it('should correctly generate line for bcrypt', () => {
+    const bcryptAlgoConfig = {
+      algorithm: HtpasswdHashAlgorithm.bcrypt,
+      rounds: 2,
+    };
+    expect(generateHtpasswdLine(user, passwd, bcryptAlgoConfig)).toMatchSnapshot();
+  });
+});
+
+describe('addUserToHTPasswd - bcrypt', () => {
+  beforeAll(mockTimeAndRandomBytes);
 
   it('should add new htpasswd to the end', () => {
     const input = ['', 'username', 'password'];
-    expect(addUserToHTPasswd(input[0], input[1], input[2])).toMatchSnapshot();
+    expect(addUserToHTPasswd(input[0], input[1], input[2], defaultHashConfig)).toMatchSnapshot();
   });
 
   it('should add new htpasswd to the end in multiline input', () => {
     const body = `test1:$6b9MlB3WUELU:autocreated 2017-11-06T18:17:21.957Z
     test2:$6FrCaT/v0dwE:autocreated 2017-12-14T13:30:20.838Z`;
     const input = [body, 'username', 'password'];
-    expect(addUserToHTPasswd(input[0], input[1], input[2])).toMatchSnapshot();
+    expect(addUserToHTPasswd(input[0], input[1], input[2], defaultHashConfig)).toMatchSnapshot();
   });
 
   it('should throw an error for incorrect username with space', () => {
     const [a, b, c] = ['', 'firstname lastname', 'password'];
-    expect(() => addUserToHTPasswd(a, b, c)).toThrowErrorMatchingSnapshot();
-  });
-});
-
-// ToDo: mock crypt3 with false
-describe('addUserToHTPasswd - crypto', () => {
-  it('should create password with crypto', () => {
-    jest.resetModules();
-    jest.doMock('../src/crypt3.ts', () => false);
-    const input = ['', 'username', 'password'];
-    const utils = require('../src/utils.ts');
-    expect(utils.addUserToHTPasswd(input[0], input[1], input[2])).toEqual(
-      'username:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=:autocreated 2018-01-14T11:17:40.712Z\n'
-    );
+    expect(() => addUserToHTPasswd(a, b, c, defaultHashConfig)).toThrowErrorMatchingSnapshot();
   });
 });
 
@@ -207,61 +228,60 @@ describe('sanityCheck', () => {
     expect(verifyFn).toHaveBeenCalledTimes(1);
   });
 
-  test('should throw error for existing username and password with max number of users reached', async () => {
-    const verifyFn = jest.fn(() => true);
-    const input = await sanityCheck('test', users.test, verifyFn, users, 1);
-    expect(input.status).toEqual(409);
-    expect(input.message).toEqual('username is already registered');
-    expect(verifyFn).toHaveBeenCalledTimes(1);
-  });
+  test(
+    'should throw error for existing username and password with max number ' + 'of users reached',
+    async () => {
+      const verifyFn = jest.fn(() => true);
+      const input = await sanityCheck('test', users.test, verifyFn, users, 1);
+      expect(input.status).toEqual(409);
+      expect(input.message).toEqual('username is already registered');
+      expect(verifyFn).toHaveBeenCalledTimes(1);
+    }
+  );
 });
 
 describe('changePasswordToHTPasswd', () => {
-  test('should throw error for wrong password', () => {
+  test('should throw error for wrong password', async () => {
     const body = 'test:$6b9MlB3WUELU:autocreated 2017-11-06T18:17:21.957Z';
 
     try {
-      changePasswordToHTPasswd(body, 'test', 'somerandompassword', 'newPassword');
-    } catch (error) {
-      expect(error.message).toEqual('Invalid old Password');
+      await changePasswordToHTPasswd(
+        body,
+        'test',
+        'somerandompassword',
+        'newPassword',
+        defaultHashConfig
+      );
+    } catch (error: any) {
+      expect(error.message).toEqual(
+        `Unable to change password for user 'test': invalid old password`
+      );
     }
   });
 
-  test('should change the password', () => {
+  test('should throw error when user does not exist', async () => {
+    const body = 'test:$6b9MlB3WUELU:autocreated 2017-11-06T18:17:21.957Z';
+
+    try {
+      await changePasswordToHTPasswd(
+        body,
+        'test2',
+        'somerandompassword',
+        'newPassword',
+        defaultHashConfig
+      );
+    } catch (error: any) {
+      expect(error.message).toEqual(
+        `Unable to change password for user 'test2': user does not currently exist`
+      );
+    }
+  });
+
+  test('should change the password', async () => {
     const body = 'root:$6qLTHoPfGLy2:autocreated 2018-08-20T13:38:12.164Z';
 
-    expect(changePasswordToHTPasswd(body, 'root', 'demo123', 'newPassword')).toMatchSnapshot();
-  });
-
-  test('should generate a different result on salt change', () => {
-    crypto.randomBytes = jest.fn(() => {
-      return {
-        toString: (): string => 'AB',
-      };
-    });
-
-    const body = 'root:$6qLTHoPfGLy2:autocreated 2018-08-20T13:38:12.164Z';
-
-    expect(changePasswordToHTPasswd(body, 'root', 'demo123', 'demo123')).toEqual(
-      'root:ABfaAAjDKIgfw:autocreated 2018-08-20T13:38:12.164Z'
-    );
-  });
-
-  test('should change the password when crypt3 is not available', () => {
-    jest.resetModules();
-    jest.doMock('../src/crypt3.ts', () => false);
-    const utils = require('../src/utils.ts');
-    const body = 'username:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=:autocreated 2018-01-14T11:17:40.712Z';
-    expect(utils.changePasswordToHTPasswd(body, 'username', 'password', 'newPassword')).toEqual(
-      'username:{SHA}KD1HqTOO0RALX+Klr/LR98eZv9A=:autocreated 2018-01-14T11:17:40.712Z'
-    );
-  });
-});
-
-describe('getCryptoPassword', () => {
-  test('should return the password hash', () => {
-    const passwordHash = `{SHA}y9vkk2zovmMYTZ8uE/wkkjQ3G5o=`;
-
-    expect(getCryptoPassword('demo123')).toBe(passwordHash);
+    expect(
+      await changePasswordToHTPasswd(body, 'root', 'demo123', 'newPassword', defaultHashConfig)
+    ).toMatchSnapshot();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,12 +260,13 @@ importers:
 
   plugins/htpasswd:
     specifiers:
-      '@types/bcryptjs': ^2.4.2
+      '@types/bcryptjs': 2.4.2
       '@verdaccio/file-locking': workspace:10.3.0
       '@verdaccio/types': workspace:10.5.1
       apache-md5: 1.1.7
       bcryptjs: 2.4.3
       http-errors: 2.0.0
+      mockdate: 3.0.2
       unix-crypt-td-js: 1.1.4
     dependencies:
       '@verdaccio/file-locking': link:../../core/file-locking
@@ -276,6 +277,7 @@ importers:
     devDependencies:
       '@types/bcryptjs': 2.4.2
       '@verdaccio/types': link:../../core/types
+      mockdate: 3.0.2
 
   plugins/local-storage:
     specifiers:
@@ -7386,6 +7388,10 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
+
+  /mockdate/3.0.2:
+    resolution: {integrity: sha512-ldfYSUW1ocqSHGTK6rrODUiqAFPGAg0xaHqYJ5tvj1hQyFsjuHpuWgWFTZWwDVlzougN/s2/mhDr8r5nY5xDpA==}
+    dev: true
 
   /ms/2.0.0:
     resolution: {integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=}


### PR DESCRIPTION
> ⚠️  TLDR: Use bcrypt is much secure, verdaccio 5 uses `crypt` by default to avoid breakign changes, next major (v6) will switch to bcrypt by default and invalidate your current passwords. This does not apply if you are using your own authentication plugin. 

<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

Also, we need the scopes involved (aka package folder names):

eg:

-->
**Type:** feat
**Scope:** plugin

The following has been addressed in the PR:

*  There is a related issue?
*  Unit or Functional tests are included in the PR

**Description:**

copied from v6 plugins by @greshilov https://github.com/verdaccio/verdaccio/pull/2072

> To avoid a breaking change, the default algorithm is `crypt`.

### Context

The current implementation of the `htpasswd` module supports multiple hash formats on verify, but only `crypt` on sign in.
`crypt` is an insecure old format, so to improve the security of the new `verdaccio` release we introduce the support of multiple hash algorithms on sign in step.

### New hashing algorithms

The new possible hash algorithms to use are `bcrypt`, `md5`, `sha1`. ~`bcrypt` is chosen as a default, because of its customizable complexity and overall reliability~. You can read more about them [here](https://httpd.apache.org/docs/2.4/misc/password_encryptions.html).

Two new properties are added to `auth` section in the configuration file:

- `algorithm` to choose the way you want to hash passwords.
- `rounds` is used to determine `bcrypt` complexity. So one can improve security according to increasing computational power.

Example of the new `auth` config file section:

```yaml
auth:
htpasswd:
  file: ./htpasswd
  max_users: 1000
  # Hash algorithm, possible options are: "bcrypt", "md5", "sha1", "crypt".
  algorithm: bcrypt
  # Rounds number for "bcrypt", will be ignored for other algorithms.
  rounds: 10
```

