### PR TITLE
fix: regresion wrong new storage path reference

### DIFF
--- a/.changeset/plenty-donkeys-begin.md
+++ b/.changeset/plenty-donkeys-begin.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/local-storage': patch
+---
+
+fix: regresion wrong new storage path reference

--- a/plugins/local-storage/src/token.ts
+++ b/plugins/local-storage/src/token.ts
@@ -21,7 +21,9 @@ export default class TokenActions implements ITokenActions {
   }
 
   public _dbGenPath(dbName: string, config: Config): string {
-    return Path.join(Path.resolve(Path.dirname(config.config_path || ''), config.storage as string, dbName));
+    return Path.join(
+      Path.resolve(Path.dirname(config.self_path || ''), config.storage as string, dbName)
+    );
   }
 
   private async getTokenDb(): Promise<low.LowdbAsync<any>> {


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

Also, we need the scopes involved (aka package folder names):

eg:

-->
**Type:** fix
**Scope:** local-storage

The following has been addressed in the PR:

*  There is a related issue?

This might be the issue some has been reported the packages are not found. Workaround was using absolute path.

*  Unit or Functional tests are included in the PR

**Description:**

Regression here https://github.com/verdaccio/monorepo/pull/394 
