### PR TITLE
core: update package aws-sdk

### DIFF
--- a/plugins/aws-s3-storage/package.json
+++ b/plugins/aws-s3-storage/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@verdaccio/commons-api": "10.2.0",
     "@verdaccio/streams": "workspace:10.2.1",
-    "aws-sdk": "^2.607.0"
+    "aws-sdk": "^2.1030.0"
   },
   "devDependencies": {
     "@verdaccio/legacy-types": "workspace:1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,7 +252,7 @@ importers:
         specifier: workspace:10.2.1
         version: link:../../core/streams
       aws-sdk:
-        specifier: ^2.607.0
+        specifier: ^2.1030.0
         version: 2.1030.0
     devDependencies:
       '@verdaccio/legacy-types':


### PR DESCRIPTION
Update of `aws-sdk` package inside plugin `verdaccio-aws-s3-storage`, in order to try to fix https://github.com/verdaccio/monorepo/issues/668

We did it locally and for now the crash didn't came back 
