### PR TITLE
fix: handle s3 errors without a status code

### DIFF
--- a/plugins/aws-s3-storage/src/s3Errors.ts
+++ b/plugins/aws-s3-storage/src/s3Errors.ts
@@ -44,6 +44,6 @@ export function convertS3Error(err: AWSError): VerdaccioError {
       return getInternalError('request aborted');
     default:
       // @ts-ignore
-      return getCode(err.statusCode, err.message);
+      return getCode(err.statusCode || HTTP_STATUS.INTERNAL_ERROR, err.message);
   }
 }


### PR DESCRIPTION
**Type:** Bug
**Scope:** verdaccio-aws-s3-storage

The following has been addressed in the PR:

* When an error occurs with the SDK outside of an HTTP request then the error's statusCode will be `undefined`, which will trigger a TypeError in common code outside the plugin, masking the true error (eg. missing AWS credentials)

This change sets a fallback 500 status code so that error handling will continue.

Resolves #695
