### PR TITLE
fix: active directory missing logging option

### DIFF
--- a/.changeset/eight-mangos-tickle.md
+++ b/.changeset/eight-mangos-tickle.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/active-directory': patch
+---
+
+fix: active directory missing logging option

--- a/plugins/active-directory/src/active-directory.ts
+++ b/plugins/active-directory/src/active-directory.ts
@@ -28,6 +28,7 @@ class ActiveDirectoryPlugin implements IPluginAuth<ActiveDirectoryConfig> {
       domainSuffix: undefined,
       username,
       password,
+      logging: this.logger
     };
 
     const connection = new ActiveDirectory(connectionConfig);


### PR DESCRIPTION

**Description:**

- Missing logging option https://www.npmjs.com/package/activedirectory2
- #702 fails here https://github.com/ldapjs/node-ldapjs/blob/master/lib/client/client.js#L873

Resolves #https://github.com/verdaccio/monorepo/issues/702
