### PR TITLE
fix: externalize bare Node.js built-in imports in Vite configs

### DIFF
--- a/.changeset/odd-pumas-allow.md
+++ b/.changeset/odd-pumas-allow.md
@@ -1,0 +1,10 @@
+---
+'@verdaccio/local-storage-legacy': patch
+'@verdaccio/legacy-types': patch
+'verdaccio-auth-memory': patch
+'@verdaccio/file-locking': patch
+'verdaccio-memory': patch
+'@verdaccio/streams': patch
+---
+
+fix: typeError cjs vite

--- a/core/deprecated-types/src/plugins/storage.ts
+++ b/core/deprecated-types/src/plugins/storage.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from 'stream';
+import { PassThrough } from 'node:stream';
 
 import type { Callback, CallbackAction, StringValue } from '../commons';
 import type { Config, Logger } from '../configuration';

--- a/core/file-locking/src/lockfile.ts
+++ b/core/file-locking/src/lockfile.ts
@@ -1,5 +1,5 @@
-import fs from 'node:fs';
 import locker from 'lockfile';
+import fs from 'node:fs';
 
 import type { Callback } from '@verdaccio/legacy-types';
 

--- a/core/file-locking/src/lockfile.ts
+++ b/core/file-locking/src/lockfile.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 import locker from 'lockfile';
 
 import type { Callback } from '@verdaccio/legacy-types';

--- a/core/file-locking/src/readFile.ts
+++ b/core/file-locking/src/readFile.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 
 import type { Callback } from '@verdaccio/legacy-types';
 

--- a/core/file-locking/src/utils.ts
+++ b/core/file-locking/src/utils.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
+import fs from 'node:fs';
 import locker from 'lockfile';
-import path from 'path';
+import path from 'node:path';
 
 export const statDir = (name: string): Promise<Error | null> => {
   return new Promise((resolve, reject): void => {

--- a/core/file-locking/src/utils.ts
+++ b/core/file-locking/src/utils.ts
@@ -1,5 +1,5 @@
-import fs from 'node:fs';
 import locker from 'lockfile';
+import fs from 'node:fs';
 import path from 'node:path';
 
 export const statDir = (name: string): Promise<Error | null> => {

--- a/core/file-locking/vite.config.ts
+++ b/core/file-locking/vite.config.ts
@@ -1,4 +1,5 @@
-import { resolve } from 'path';
+import { builtinModules } from 'node:module';
+import { resolve } from 'node:path';
 import dts from 'vite-plugin-dts';
 import { defineConfig } from 'vitest/config';
 
@@ -20,7 +21,7 @@ export default defineConfig({
     },
     outDir: 'lib',
     rollupOptions: {
-      external: [/^node:/, 'fs', 'path', 'lockfile'],
+      external: [/^node:/, ...builtinModules, 'lockfile'],
       output: {
         exports: 'named',
         preserveModules: true,

--- a/core/streams/src/index.ts
+++ b/core/streams/src/index.ts
@@ -1,5 +1,5 @@
-import type { TransformOptions } from 'stream';
-import { PassThrough } from 'stream';
+import type { TransformOptions } from 'node:stream';
+import { PassThrough } from 'node:stream';
 
 export interface IReadTarball {
   abort?: () => void;

--- a/core/streams/vite.config.ts
+++ b/core/streams/vite.config.ts
@@ -1,4 +1,5 @@
-import { resolve } from 'path';
+import { builtinModules } from 'node:module';
+import { resolve } from 'node:path';
 import dts from 'vite-plugin-dts';
 import { defineConfig } from 'vitest/config';
 
@@ -20,7 +21,7 @@ export default defineConfig({
     },
     outDir: 'lib',
     rollupOptions: {
-      external: [/^node:/, 'stream'],
+      external: [/^node:/, ...builtinModules],
       output: {
         exports: 'named',
         preserveModules: true,

--- a/plugins/auth-memory/vite.config.ts
+++ b/plugins/auth-memory/vite.config.ts
@@ -1,4 +1,5 @@
-import { resolve } from 'path';
+import { builtinModules } from 'node:module';
+import { resolve } from 'node:path';
 import dts from 'vite-plugin-dts';
 import { defineConfig } from 'vitest/config';
 
@@ -20,7 +21,7 @@ export default defineConfig({
     },
     outDir: 'lib',
     rollupOptions: {
-      external: [/^node:/, /^@verdaccio\//, 'debug'],
+      external: [/^node:/, ...builtinModules, /^@verdaccio\//, 'debug'],
       output: {
         exports: 'named',
         preserveModules: true,

--- a/plugins/local-storage-legacy/src/local-database.ts
+++ b/plugins/local-storage-legacy/src/local-database.ts
@@ -1,8 +1,8 @@
 import buildDebug from 'debug';
-import fs from 'node:fs';
 import globby from 'globby';
 import _ from 'lodash';
 import mkdirp from 'mkdirp';
+import fs from 'node:fs';
 import Path from 'node:path';
 import sanitize from 'sanitize-filename';
 

--- a/plugins/local-storage-legacy/src/local-database.ts
+++ b/plugins/local-storage-legacy/src/local-database.ts
@@ -1,9 +1,9 @@
 import buildDebug from 'debug';
-import fs from 'fs';
+import fs from 'node:fs';
 import globby from 'globby';
 import _ from 'lodash';
 import mkdirp from 'mkdirp';
-import Path from 'path';
+import Path from 'node:path';
 import sanitize from 'sanitize-filename';
 
 import { errorUtils } from '@verdaccio/core';

--- a/plugins/local-storage-legacy/vite.config.ts
+++ b/plugins/local-storage-legacy/vite.config.ts
@@ -1,4 +1,5 @@
-import { resolve } from 'path';
+import { builtinModules } from 'node:module';
+import { resolve } from 'node:path';
 import dts from 'vite-plugin-dts';
 import { defineConfig } from 'vitest/config';
 
@@ -27,18 +28,16 @@ export default defineConfig({
     rollupOptions: {
       external: [
         /^node:/,
+        ...builtinModules,
         /^@verdaccio\//,
         'debug',
-        'fs',
         'globby',
-        'path',
         'lodash',
         'lowdb',
         'lowdb/adapters/FileAsync',
         'lowdb/adapters/Memory',
         'mkdirp',
         'sanitize-filename',
-        'stream',
       ],
       output: {
         exports: 'named',

--- a/plugins/memory/src/memory-handler.ts
+++ b/plugins/memory/src/memory-handler.ts
@@ -1,5 +1,5 @@
 import MemoryFileSystem from 'memory-fs';
-import path from 'path';
+import path from 'node:path';
 
 import type { VerdaccioError } from '@verdaccio/core';
 import { errorUtils } from '@verdaccio/core';

--- a/plugins/memory/vite.config.ts
+++ b/plugins/memory/vite.config.ts
@@ -1,4 +1,5 @@
-import { resolve } from 'path';
+import { builtinModules } from 'node:module';
+import { resolve } from 'node:path';
 import dts from 'vite-plugin-dts';
 import { defineConfig } from 'vitest/config';
 
@@ -20,7 +21,7 @@ export default defineConfig({
     },
     outDir: 'lib',
     rollupOptions: {
-      external: [/^node:/, /^@verdaccio\//, 'memory-fs', 'stream'],
+      external: [/^node:/, ...builtinModules, /^@verdaccio\//, 'memory-fs'],
       output: {
         exports: 'named',
         preserveModules: true,


### PR DESCRIPTION
**Type:** bug fix
**Scope:** plugins/memory, plugins/auth-memory, plugins/local-storage-legacy, core/file-locking, core/streams, core/deprecated-types

## Description

Fixes the regression introduced in `verdaccio-memory@10.4.2` after migrating from Babel to Vite 8.

**Root cause:** The Vite `rollupOptions.external` config used `/^node:/` regex to externalize Node.js built-ins, but the source code imports them without the `node:` prefix (e.g., `import path from 'path'`). Since bare `'path'` doesn't match `/^node:/`, Vite treats it as a browser dependency and replaces it with a `__vite_browser_external` shim — a dummy object with no methods. At runtime, `path.dirname()` throws `TypeError: import___vite_browser_external.default.dirname is not a function`.

**Fix (applied across all packages):**

1. **Vite configs** — Added `builtinModules` from `node:module` to the `external` array as a safety net, so any bare Node.js built-in import is always externalized regardless of prefix. Removed manually-listed builtins that are now covered (`'fs'`, `'path'`, `'stream'`).

2. **Source imports** — Migrated all bare Node.js built-in imports to use the `node:` prefix (`'path'` → `'node:path'`, `'fs'` → `'node:fs'`, `'stream'` → `'node:stream'`), which is the modern Node.js convention and directly matches the existing `/^node:/` external regex.

Resolves https://github.com/verdaccio/verdaccio/issues/5828